### PR TITLE
Update default filename in schema

### DIFF
--- a/packages/rolldown/src/cli/arguments/schema.ts
+++ b/packages/rolldown/src/cli/arguments/schema.ts
@@ -9,7 +9,7 @@ export const cliOptionsSchema = z
     config: z
       .string()
       .or(z.boolean())
-      .describe('Path to the config file (default: `rollup.config.js`)')
+      .describe('Path to the config file (default: `rolldown.config.js`)')
       .optional(),
     help: z.boolean().describe('Show help').optional(),
     version: z.boolean().describe('Show version number').optional(),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

After looking at the help

```
bunx rolldown --help
Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API. (rolldown v0.13.2)                                                                                                                                                                             

USAGE rolldown -c <config> or rolldown <input> <options>
                                                                                                                                                                                                                                                                      
OPTIONS                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                      
  --config -c, <filename>     Path to the config file (default: rollup.config.js).   
```

I noticed that the default filename `rollup.config.js` did not working when trying `bunx rolldown -c`.